### PR TITLE
Lazy load embedded videos for improved performance

### DIFF
--- a/src/lib/components/IntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount } from "svelte"
+
+  export let once = false
+  export let top = 0
+  export let bottom = 0
+  export let left = 0
+  export let right = 0
+
+  let intersecting = false
+  let container: HTMLDivElement
+
+  onMount(() => {
+    if (typeof IntersectionObserver !== "undefined") {
+      const rootMargin = `${bottom}px ${left}px ${top}px ${right}px`
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          intersecting = entries[0].isIntersecting
+          if (intersecting && once) {
+            observer.unobserve(container)
+          }
+        },
+        {
+          rootMargin,
+        }
+      )
+
+      observer.observe(container)
+      return () => observer.unobserve(container)
+    }
+
+    function handler() {
+      const bcr = container.getBoundingClientRect()
+      intersecting =
+        bcr.bottom + bottom > 0 &&
+        bcr.right + right > 0 &&
+        bcr.top - top < window.innerHeight &&
+        bcr.left - left < window.innerWidth
+
+      if (intersecting && once) {
+        window.removeEventListener("scroll", handler)
+      }
+    }
+
+    window.addEventListener("scroll", handler)
+    return () => window.removeEventListener("scroll", handler)
+  })
+</script>
+
+<div bind:this={container}>
+  <slot {intersecting} />
+</div>
+
+<style>
+  div {
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/src/lib/components/IntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver.svelte
@@ -51,10 +51,3 @@
 <div bind:this={container}>
   <slot {intersecting} />
 </div>
-
-<style>
-  div {
-    width: 100%;
-    height: 100%;
-  }
-</style>

--- a/src/lib/components/Video.svelte
+++ b/src/lib/components/Video.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Button from "$lib/components/Button.svelte"
+  import IntersectionObserver from "./IntersectionObserver.svelte"
 
   export let videolink: string = ""
   export let transcriptlink: string = ""
@@ -29,30 +30,34 @@
   let thumbnail = `https://img.youtube.com/vi/${videoID}/maxresdefault.jpg`
 </script>
 
-<div class="media | stack">
-  <div class="frame" style="background-image: url({thumbnail}); background-size: cover;">
-    <iframe
-      class="youtube"
-      src={videoEmbed}
-      title="YouTube video player"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media;"
-      allowfullscreen />
-    <a class="play | imposter box" href={videolink}>
-      <span class="visually-hidden">Watch on YouTube</span>
-      <svg width="34" height="34">
-        <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M5.92725 3.30884V30.6912L29.1917 17L5.92725 3.30884ZM2.83325 2.76959C2.83325 0.626828 5.18123 -0.701815 7.03745 0.39057L31.2182 14.621C33.0383 15.692 33.0383 18.3079 31.2182 19.379L7.03745 33.6094C5.18123 34.7018 2.83325 33.3732 2.83325 31.2304V2.76959Z"
-          fill="white" />
-      </svg>
-    </a>
+<IntersectionObserver let:intersecting once top={400}>
+  <div class="media | stack">
+    <div class="frame" style="background-image: url({thumbnail}); background-size: cover;">
+      {#if intersecting}
+        <iframe
+          class="youtube"
+          src={videoEmbed}
+          title="YouTube video player"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media;"
+          allowfullscreen />
+      {/if}
+      <a class="play | imposter box" href={videolink}>
+        <span class="visually-hidden">Watch on YouTube</span>
+        <svg width="34" height="34">
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M5.92725 3.30884V30.6912L29.1917 17L5.92725 3.30884ZM2.83325 2.76959C2.83325 0.626828 5.18123 -0.701815 7.03745 0.39057L31.2182 14.621C33.0383 15.692 33.0383 18.3079 31.2182 19.379L7.03745 33.6094C5.18123 34.7018 2.83325 33.3732 2.83325 31.2304V2.76959Z"
+            fill="white" />
+        </svg>
+      </a>
+    </div>
+    {#if transcriptlink}
+      <Button link={transcriptlink}>Read transcript (Google docs)</Button>
+    {/if}
   </div>
-  {#if transcriptlink}
-    <Button link={transcriptlink}>Read transcript (Google docs)</Button>
-  {/if}
-</div>
+</IntersectionObserver>
 
 <style>
   .media {


### PR DESCRIPTION
Interactivity on home and blog were being blocked by all embedded videos loading at once. This will defer loading the iframe until it's about to be scrolled into view. Drastically improves responsiveness on lower specced devices.