### PR TITLE
Add support for ssl in dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sveltejs/kit": "^1.20.4",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
+    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "autoprefixer": "^10.4.14",
     "cheerio": "^1.0.0-rc.12",
     "cssnano": "^6.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { sveltekit } from "@sveltejs/kit/vite"
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import type { UserConfig } from "vite"
 
 const config: UserConfig = {
-  plugins: [sveltekit()],
+  plugins: [basicSsl(), sveltekit()],
   server: {
     host: true,
+    https: true,
   },
   css: {
     preprocessorOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,6 +820,11 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vitejs/plugin-basic-ssl@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz#48c46eab21e0730921986ce742563ae83fe7fe34"
+  integrity sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
Adds basic support for SSL in dev environment. Running via https allows for a secure context to test things like `navigator.clipboard.writeText`

See issue: https://github.com/wharfkit/website/issues/133

