### PR TITLE
Fix selector for visited button links

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -111,7 +111,8 @@ button {
   isolation: isolate;
 }
 
-.button:is(:visited, :hover) {
+.button:visited,
+.button:hover {
   color: var(--button-text, var(--color-primary-900));
 }
 


### PR DESCRIPTION
Removing the `:is()` fixes the specificity issues in safari.