### PR TITLE
fix: blog overflow

### DIFF
--- a/src/lib/components/FeaturedPost.svelte
+++ b/src/lib/components/FeaturedPost.svelte
@@ -10,7 +10,7 @@
 <article>
   <div class="image">
     <a href={path}>
-      <img src={image} alt="blog post header" />
+      <img src={image} alt="blog post header" width="940" height="528" />
     </a>
   </div>
 
@@ -62,13 +62,22 @@
   .image {
     grid-column: 3 / 7;
     grid-row: 1;
+    background: hsl(228, 15%, 18%);
+    border-radius: var(--border-radius);
   }
 
   img {
     border-radius: var(--border-radius);
+    color: var(--wharf-blue);
+    width: auto;
+    height: auto;
   }
 
   @media (max-width: 1000px) {
+    header {
+      border-radius: 0;
+    }
+
     .card {
       grid-column: 1 / 7;
       grid-row: 2;

--- a/src/lib/components/PostPreview.svelte
+++ b/src/lib/components/PostPreview.svelte
@@ -6,7 +6,9 @@
 </script>
 
 <a href={path}>
-  <img src={image} alt="blog post header" loading="lazy" />
+  <picture>
+    <img src={image} alt="blog post header" loading="lazy" width="552" height="310" />
+  </picture>
   <p class="tag">{capitalize(tags[0])}</p>
   <h2>{title}</h2>
   <p class="description">{description}</p>
@@ -29,9 +31,17 @@
     font-size: var(--fs-2);
   }
 
-  img {
-    border-radius: var(--border-radius);
+  picture {
+    background: hsl(228, 15%, 18%);
     margin-bottom: var(--space-xs);
+    border-radius: var(--border-radius);
+  }
+
+  img {
+    border-radius: inherit;
+    height: auto;
+    width: auto;
+    color: var(--wharf-blue);
   }
 
   .description {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -29,6 +29,7 @@
 </script>
 
 <svelte:head>
+  <link rel="preload" as="image" href={newestPost.image} />
   <style>
     /* prettier-ignore */
     body[data-theme="dark"] {
@@ -146,12 +147,23 @@
     list-style: none;
     padding-inline: unset;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
+    /* grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr)); */
+    /* grid-template-columns: 1fr 1fr; */
     column-gap: var(--space-xl);
     row-gap: var(--space-3xl);
   }
 
+  @media screen and (min-width: 600px) {
+    .posts {
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    }
+  }
+
   @media screen and (min-width: 900px) {
+    .posts {
+      grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
+    }
+
     aside {
       display: block;
       width: 100%;


### PR DESCRIPTION
Fixes grid layout for small screens
adds default widths to `img` tags to reduce CLS
adds background placeholder to images for less jarring load 

